### PR TITLE
[TASK] Add TYPO3 v14 compatibility

### DIFF
--- a/Classes/Service/ChallengeResponseService.php
+++ b/Classes/Service/ChallengeResponseService.php
@@ -6,19 +6,19 @@ namespace Derhansen\PowermailCrshield\Service;
 
 use Psr\Log\LoggerInterface;
 use TYPO3\CMS\Core\Context\Context;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Crypto\HashService;
 
 class ChallengeResponseService
 {
     public function __construct(
         protected readonly LoggerInterface $logger,
-        protected readonly Context $context
-    ) {
-    }
+        protected readonly Context $context,
+        protected readonly HashService $hashService
+    ) {}
 
     public function getChallenge(string $method, int $expirationTime, int $delay, string $salt): string
     {
-        return $method . '|' . $expirationTime . '|' . GeneralUtility::hmac((string)$expirationTime, $salt) . '|' .
+        return $method . '|' . $expirationTime . '|' . $this->hashService->hmac((string)$expirationTime, $salt) . '|' .
             $delay;
     }
 
@@ -42,7 +42,7 @@ class ChallengeResponseService
         }
 
         [$method, $expirationTime, $clientData] = explode('|', $decodedResponse);
-        $knownHmac = GeneralUtility::hmac($expirationTime, $salt);
+        $knownHmac = $this->hashService->hmac($expirationTime, $salt);
         $calculatedData = $this->getCalculatedData($knownHmac, $method);
 
         if ($calculatedData !== $clientData) {

--- a/Classes/ViewHelpers/CrFieldViewHelper.php
+++ b/Classes/ViewHelpers/CrFieldViewHelper.php
@@ -21,7 +21,6 @@ class CrFieldViewHelper extends AbstractFormFieldViewHelper
 
     protected $tagName = 'input';
     private int $currentTimestamp;
-    private int $cacheTimeOutDefault = 86400;
     private array $settings;
 
     public function __construct(
@@ -107,12 +106,14 @@ class CrFieldViewHelper extends AbstractFormFieldViewHelper
     {
         $pageInformation = $this->getRequest()->getAttribute('frontend.page.information');
         $typoScriptConfigArray = $this->getRequest()->getAttribute('frontend.typoscript')->getConfigArray();
+        // TYPO3 v14 dropped the $defaultLifetime (int) argument from
+        // CacheLifetimeCalculator::calculateLifetimeForPage(); the signature is
+        // now (int $pageId, array $pageRecord, array $renderingInstructions, Context $context).
         return GeneralUtility::makeInstance(CacheLifetimeCalculator::class)
             ->calculateLifetimeForPage(
                 $pageInformation->getId(),
                 $pageInformation->getPageRecord(),
                 $typoScriptConfigArray,
-                $this->cacheTimeOutDefault,
                 $this->context
             );
     }

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,12 @@
             "email": "derhansen@gmail.com",
             "homepage": "https://www.derhansen.com",
             "role": "Developer"
+        },
+        {
+            "name": "Krzysztof Napora",
+            "email": "k.napora@drblitz-weblab.com",
+            "homepage": "https://drblitz-weblab.com",
+            "role": "Contributor"
         }
     ],
     "keywords": [
@@ -25,8 +31,8 @@
         "GPL-2.0-or-later"
     ],
     "require": {
-        "typo3/cms-core": "^13.4",
-        "in2code/powermail": "^13.0"
+        "typo3/cms-core": "^14.0",
+        "in2code/powermail": "^14.0"
     },
     "replace": {
         "typo3-ter/powermail-crshield": "self.version"

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -10,11 +10,11 @@ $EM_CONF[$_EXTKEY] = [
     'uploadfolder' => '0',
     'createDirs' => '',
     'clearCacheOnLoad' => 1,
-    'version' => '2.0.1',
+    'version' => '3.0.0',
     'constraints' => [
         'depends' => [
-            'typo3' => '13.4.0-13.4.99',
-            'powermail' => '13.0.0-13.99.99',
+            'typo3' => '14.0.0-14.4.99',
+            'powermail' => '14.0.0-14.99.99',
         ],
         'conflicts' => [],
         'suggests' => [],


### PR DESCRIPTION
Migrate the extension to TYPO3 v14:

- ChallengeResponseService: replace the removed GeneralUtility::hmac() with the injected HashService (TYPO3\CMS\Core\Crypto\HashService).
- CrFieldViewHelper: adapt to the changed CacheLifetimeCalculator::calculateLifetimeForPage() signature, which dropped the $defaultLifetime argument in v14, and remove the now-unused $cacheTimeOutDefault property.
- Raise composer and ext_emconf constraints to TYPO3 ^14.0 and powermail ^14.0.
- Add Krzysztof Napora (DR BLITZ WEBLAB) as contributor.